### PR TITLE
feat :add boards

### DIFF
--- a/src/components/BoardRoutes/BoardRoutes.tsx
+++ b/src/components/BoardRoutes/BoardRoutes.tsx
@@ -19,9 +19,6 @@ const Container = styled.div`
   overflow: scroll;
   margin: 0;
 `;
-const InnerContainer = styled.div`
-  margin: 0;
-`;
 
 const BoardRoutes = () => {
   const boardId = getBoardId();
@@ -138,15 +135,7 @@ const BoardRoutes = () => {
           {(provided) => (
             <Container ref={provided.innerRef} {...provided.droppableProps}>
               {screenResult?.map((item, index) => (
-                <InnerContainer>
-                  <Column
-                    key={item._id}
-                    column={item}
-                    setBoardTask={setBoardTask}
-                    localTask={boardTask}
-                    index={index}
-                  />
-                </InnerContainer>
+                <Column key={item._id} column={item} setBoardTask={setBoardTask} localTask={boardTask} index={index} />
               ))}
               {provided.placeholder}
             </Container>


### PR DESCRIPTION
Button for column creation is displayed 1 point
If a board contains at least one column - a button for task creation is displayed/become enabled as well 1 points
A modal windows with forms is displayed for column and task creations 3 points
A vertical scrollbar is displayed in the column when overflowing with the number of column tasks 2 points
The page itself on the current route doesn't have a vertical scrollbar 1 points
With the help of drag-n-drop, we can swap columns. 3 points
With the help of drag-n-drop, we can change the order of tasks within a column. 3 points
With the help of drag-n-drop, we can change the task belonging to the column. 5 points

result 19